### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: .NET test
       run: dotnet test src/MoqToNSubstituteConverter.Tests/MoqToNSubstituteConverter.Tests.csproj -c Release
     - name: .NET publish
@@ -40,7 +40,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: webapp
-        path: src/MoqToNSubstituteConverter.Web/bin/Release/net7.0/publish
+        path: src/MoqToNSubstituteConverter.Web/bin/Release/net8.0/publish
 
 
   #Deploy the artifacts to Azure

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-next-version: 0.3.0
+next-version: 0.4.0

--- a/src/MoqToNSubstituteConverter.Tests/MoqToNSubstituteConverter.Tests.csproj
+++ b/src/MoqToNSubstituteConverter.Tests/MoqToNSubstituteConverter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/MoqToNSubstituteConverter.Web/MoqToNSubstituteConverter.Web.csproj
+++ b/src/MoqToNSubstituteConverter.Web/MoqToNSubstituteConverter.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ApplicationInsightsResourceId>/subscriptions/65b8d298-e5bd-4735-912e-8b9c510c4e00/resourceGroups/MoqToNSubstitute/providers/microsoft.insights/components/MoqToNSubstitute-AppInsights</ApplicationInsightsResourceId>

--- a/src/MoqToNSubstituteConverter/MoqToNSubstituteConverter.csproj
+++ b/src/MoqToNSubstituteConverter/MoqToNSubstituteConverter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This pull request includes changes to update the target framework and versioning of the project. The most important changes are updating the target framework of the `MoqToNSubstituteConverter.Web` project to .NET 8.0 and updating the target framework of the main project (`MoqToNSubstituteConverter.csproj`) to .NET 8.0.

Main framework changes:

* <a href="diffhunk://#diff-19f93fcb88b535ca426c06dfc515aeb6b4de02b10aae8327e25b56c7ed216bcaL4-R4">`src/MoqToNSubstituteConverter.Web/MoqToNSubstituteConverter.Web.csproj`</a>: Updated the target framework of the `MoqToNSubstituteConverter.Web` project to .NET 8.0.
* <a href="diffhunk://#diff-4e1481b36e1ea449d3ef3021fc02d1c32e3359a7d4430b83aa92ea687b55d726L4-R4">`src/MoqToNSubstituteConverter/MoqToNSubstituteConverter.csproj`</a>: Updated the target framework in `MoqToNSubstituteConverter.csproj` to .NET 8.0, changing the main project's target framework to .NET 8.0.

Versioning changes:

* <a href="diffhunk://#diff-1b800222c322c27580a65856212fc4fd9bf1128603cb0864b2e85f6f22b567c9L1-R1">`GitVersion.yml`</a>: Updated the next version of the project to `0.4.0` in the `GitVersion.yml` file.

Testing framework changes:

* <a href="diffhunk://#diff-e4bb210982e7d47bdaecb279ef9beb6fa446a2acd088cab3e673dc6a00328dcdL4-R4">`src/MoqToNSubstituteConverter.Tests/MoqToNSubstituteConverter.Tests.csproj`</a>: Updated the target framework of the tests project to .NET 8.0.

Workflow changes:

* <a href="diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L43-R43">`.github/workflows/workflow.yml`</a>: Updated the published artifacts path and the .NET version used in the workflow file (`workflow.yml`). <a href="diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L43-R43">[1]</a> <a href="diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L34-R34">[2]</a>